### PR TITLE
Remove `object` properties that are incompatible with `string` types

### DIFF
--- a/transfer_compute_flow_schema.json
+++ b/transfer_compute_flow_schema.json
@@ -64,17 +64,13 @@
                     "type": "string",
                     "format": "uuid",
                     "title": "Globus Compute Endpoint ID",
-                    "description": "The UUID of the Globus Compute endpoint where the function will run",
-                    "properties": {},
-                    "additionalProperties": false
+                    "description": "The UUID of the Globus Compute endpoint where the function will run"
                 },
                 "compute_function_id": {
                     "type": "string",
                     "format": "uuid",
                     "title": "Globus Compute Function ID",
-                    "description": "The UUID of the function to invoke; must be registered with the Globus Compute service",
-                    "properties": {},
-                    "additionalProperties": false
+                    "description": "The UUID of the function to invoke; must be registered with the Globus Compute service"
                 },
                 "compute_function_kwargs": {
                     "type": "object",

--- a/transfer_compute_share_flow_schema.json
+++ b/transfer_compute_share_flow_schema.json
@@ -67,17 +67,13 @@
                     "type": "string",
                     "format": "uuid",
                     "title": "Globus Compute Endpoint ID",
-                    "description": "The UUID of the funcX endpoint where the function will run.",
-                    "properties": {},
-                    "additionalProperties": false
+                    "description": "The UUID of the Globus Compute endpoint where the function will run."
                 },
                 "compute_function_id": {
                     "type": "string",
                     "format": "uuid",
                     "title": "Globus Compute Function ID",
-                    "description": "The UUID of the function to invoke; must be registered with the Globus Compute service.",
-                    "properties": {},
-                    "additionalProperties": false
+                    "description": "The UUID of the function to invoke; must be registered with the Globus Compute service."
                 },
                 "compute_function_kwargs": {
                     "type": "object",


### PR DESCRIPTION
The schemas stated that specific keys were strings but then used properties that only apply to objects.

This is an improvement opportunity for the Flows service's input validation, but fixing this now may help users.

Also: Update a reference from "funcX" to "Globus Compute".