### PR TITLE
Address stale link (registering functions)

### DIFF
--- a/flows_service.py
+++ b/flows_service.py
@@ -32,9 +32,7 @@ NATIVE_CLIENT = globus_sdk.NativeAppAuthClient(CLIENT_ID)
 
 def get_tokens(scopes=None):
     # Initiate login flow
-    NATIVE_CLIENT.oauth2_start_flow(
-        requested_scopes=scopes, refresh_tokens=True
-    )
+    NATIVE_CLIENT.oauth2_start_flow(requested_scopes=scopes, refresh_tokens=True)
     authorize_url = NATIVE_CLIENT.oauth2_get_authorize_url()
     print(f"Log in at this URL and get authorization code:\n\n{authorize_url}\n")
     auth_code = input("Enter authorization code here: ").strip()
@@ -77,10 +75,7 @@ def get_authorizer(flow_id=None):
 def create_flows_client(flow_id=None):
     if flow_id:
         return globus_sdk.SpecificFlowClient(
-            flow_id, 
-            authorizer=get_authorizer(flow_id=flow_id)
+            flow_id, authorizer=get_authorizer(flow_id=flow_id)
         )
     else:
-        return globus_sdk.FlowsClient(
-            authorizer=get_authorizer()
-        )
+        return globus_sdk.FlowsClient(authorizer=get_authorizer())

--- a/functions/tar_function.py
+++ b/functions/tar_function.py
@@ -1,7 +1,7 @@
 """ The function below is used by the tar-and-transfer flow.
 In order to use it, you must first register it with the
 Globus Compute service, as described here:
-https://globus-compute.readthedocs.io/en/latest/Tutorial.html#registering-a-function
+https://globus-compute.readthedocs.io/en/latest/sdk.html#registering-functions
 (code is also provided below).
 
 This function uses the tarfile module, which is part of the standard

--- a/trigger_tar_transfer_flow.py
+++ b/trigger_tar_transfer_flow.py
@@ -8,7 +8,6 @@ from flows_service import create_flows_client
 
 
 def run_flow(event_file):
-
     # TODO: Specify the flow to run when triggered
     flow_id = "REPLACE_WTIH_FLOW_ID"
     fc = create_flows_client(flow_id=flow_id)

--- a/trigger_transfer_compute_flow.py
+++ b/trigger_transfer_compute_flow.py
@@ -8,7 +8,6 @@ from flows_service import create_flows_client
 
 
 def run_flow(event_file):
-
     # TODO: Specify the flow to run when triggered
     flow_id = "REPLACE_WITH_FLOW_ID"
     fc = create_flows_client(flow_id=flow_id)

--- a/trigger_transfer_compute_share_flow.py
+++ b/trigger_transfer_compute_share_flow.py
@@ -8,7 +8,6 @@ from flows_service import create_flows_client
 
 
 def run_flow(event_file):
-
     # TODO: Specify the flow to run when triggered
     flow_id = "REPLACE_WITH_FLOW_ID"
     fc = create_flows_client(flow_id=flow_id)

--- a/trigger_transfer_flow.py
+++ b/trigger_transfer_flow.py
@@ -5,12 +5,10 @@ import os
 
 # This could go into a different file and be invoked without the file watcher
 from flows_service import create_flows_client
-
 from watch import FileTrigger, translate_local_path_to_globus_path
 
 
 def run_flow(event_file):
-
     # TODO: Specify the flow to run when triggered
     flow_id = "REPLACE_WITH_FLOW_ID"
     fc = create_flows_client(flow_id=flow_id)

--- a/trigger_transfer_publish_flow.py
+++ b/trigger_transfer_publish_flow.py
@@ -6,12 +6,10 @@ import os
 
 # This could go into a different file and be invoked without the file watcher
 from flows_service import create_flows_client
-
 from user import UserIdentity
 
 
 def run_flow(event_file):
-
     # TODO: Specify the flow to run when triggered
     flow_id = "REPLACE_WITH_FLOW_ID"
     fc = create_flows_client(flow_id=flow_id)

--- a/trigger_transfer_share_flow.py
+++ b/trigger_transfer_share_flow.py
@@ -8,7 +8,6 @@ from flows_service import create_flows_client
 
 
 def run_flow(event_file):
-
     # TODO: Specify the flow to run when triggered
     flow_id = "REPLACE_WITH_FLOW_ID"
     fc = create_flows_client(flow_id=flow_id)


### PR DESCRIPTION
The link was to `.../Tutorial.html` but the link path is (lower-case) `.../tutorial.html`.  However, the content of the page has moved on to the  executor which doesn't emphasize registering a function apriori.  (Perhaps it *should*, but that's a secondary discussion.)  So, update the link to a more apropos location.